### PR TITLE
서버 전반 버그 수정, 게임 아이템 점수를 클라이언트에 저장

### DIFF
--- a/assets/stage.json
+++ b/assets/stage.json
@@ -2,8 +2,8 @@
   "name": "stage",
   "version": "1.0.0",
   "data": [
-    { "id": 1000, "score": 100, "scoresPerSecond": 1 },
-    { "id": 1001, "score": 300, "scoresPerSecond": 2 },
+    { "id": 1000, "score": 50, "scoresPerSecond": 1 },
+    { "id": 1001, "score": 200, "scoresPerSecond": 2 },
     { "id": 1002, "score": 500, "scoresPerSecond": 4 },
     { "id": 1003, "score": 800, "scoresPerSecond": 8 },
     { "id": 1004, "score": 1600, "scoresPerSecond": 16 },

--- a/public/ItemController.js
+++ b/public/ItemController.js
@@ -79,12 +79,19 @@ class ItemController {
     this.items.forEach((item) => item.draw());
   }
 
+  getItemScore(itemId) {
+    const item = this.unlockedItems.find((item) => item.id === itemId);
+    if (!item) return 0;
+    return item.score;
+  }
+
   collideWith(sprite) {
     const collidedItem = this.items.find((item) => item.collideWith(sprite));
     if (collidedItem) {
       this.ctx.clearRect(collidedItem.x, collidedItem.y, collidedItem.width, collidedItem.height);
       return {
         itemId: collidedItem.id,
+        score: this.getItemScore(collidedItem.id),
       };
     }
   }

--- a/public/Score.js
+++ b/public/Score.js
@@ -34,8 +34,9 @@ class Score {
     }
   }
 
-  getItem(itemId) {
-    sendEvent(15, { itemId, timestamp: Date.now() });
+  getItem(item) {
+    this.score += item.score;
+    sendEvent(15, { itemId: item.itemId, timestamp: Date.now() });
   }
 
   reset() {

--- a/public/handlers/itemScoreHandler.js
+++ b/public/handlers/itemScoreHandler.js
@@ -1,8 +1,8 @@
 import { score as gameScore } from "../index.js";
 
 const itemScoreHandler = (payload, score) => {
-  const { score: itemScore } = payload;
-  gameScore.addScore(itemScore);
+  // const { score: itemScore } = payload;
+  // gameScore.addScore(itemScore);
 };
 
 export default itemScoreHandler;

--- a/public/handlers/stageHandler.js
+++ b/public/handlers/stageHandler.js
@@ -6,7 +6,7 @@ let itemController = null;
 
 const stageHandler = (payload) => {
   if (!score) score = Score.getInstance();
-  gameScore.setNextStage(payload.id, payload.targetScore, payload.scoresPerSecond);
+  score.setNextStage(payload.id, payload.targetScore, payload.scoresPerSecond);
   if (!itemController) itemController = ItemController.getInstance();
   itemController.unlockItem(payload.unlockedItem);
 };

--- a/public/index.js
+++ b/public/index.js
@@ -233,7 +233,7 @@ function gameLoop(currentTime) {
   }
   const collideWithItem = itemController.collideWith(player);
   if (collideWithItem && collideWithItem.itemId) {
-    score.getItem(collideWithItem.itemId);
+    score.getItem(collideWithItem);
   }
 
   // draw

--- a/src/handlers/item-score.handler.js
+++ b/src/handlers/item-score.handler.js
@@ -18,5 +18,6 @@ export const itemScoreHandler = async (userId, payload, timestamp) => {
 
   addUserItem(userId, itemScore);
 
-  return { status: "success", message: "Item obtained.", payload: { score: itemScore } };
+  // return { status: "success", message: "Item obtained.", payload: { score: itemScore } };
+  return { status: "success", message: "Item obtained." };
 };

--- a/src/handlers/stage.handler.js
+++ b/src/handlers/stage.handler.js
@@ -1,4 +1,4 @@
-import { getUnlockedItemIdByStageId } from "../init/assets.js";
+import { getItemData, getUnlockedItemIdByStageId } from "../init/assets.js";
 import { stageModelRedis as stageModel } from "../models/stage.model.js";
 import gsv from "../libs/game-state-verifier.js";
 


### PR DESCRIPTION
## 관련 Issue

<!--관련 issue 번호를 #4, close #5 같은 형식으로 추가-->
<!-- close #1, #2, close #3 -->

없음

---

## 작업 내용

- import 정보가 누락되어 있던 부분 수정
- 변수 명 변경 누락으로 인해 스테이지가 이동되지 않던 문제 수정
- 아이템 점수를 클라이언트가 직접 합산하도록 변경 (아이템 획득과 선인장 충돌이 동시 발생했을 때 마지막 아이템의 점수가 반영되지 않던 문제가 있었음)
- 서버에서 보내주던 아이템 점수 payload를 삭제
- 클라이언트의 itemScoreHandler 비활성화


---

## 비고

<!--특이사항 작성-->

-
